### PR TITLE
Warning free compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: Build
           command: |
-            cmake --build ./build
+            cmake --build ./build --parallel
       - run:
           name: Run
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /install
 /data
 /source/config/*
+**/Application Data/
 *.app
 *.desktop
 *.user

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.log
 !.gitignore
 
+#Log file
+nuclei.log
+
 #IDE
 CMakeLists.txt.user
 cmake-build-*/

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-spdlog/1.12.0
-fmt/10.1.1
+spdlog/1.13.0
+fmt/10.2.1
 date/3.0.1
 nlohmann_json/3.11.2
 qt-color-widgets/f72207b@ess-dmsc/stable

--- a/source/DecayCascadeItemModel.cpp
+++ b/source/DecayCascadeItemModel.cpp
@@ -95,7 +95,7 @@ int DecayCascadeItemModel::rowCount(const QModelIndex &parent) const
 Qt::ItemFlags DecayCascadeItemModel::flags(const QModelIndex &index) const
 {
   if (!index.isValid())
-    return 0;
+    return {};
 
   Qt::ItemFlags result = Qt::ItemIsEnabled;
 

--- a/source/ENSDFDataSource.cpp
+++ b/source/ENSDFDataSource.cpp
@@ -146,7 +146,7 @@ QList<uint16_t> ENSDFDataSource::getAvailableDataFileNumbers()
     firsttry = false;
   }
 
-  return QList<uint16_t>::fromStdList(parser.masses());
+  return parser.masses();
 }
 
 

--- a/source/NucData/Energy.cpp
+++ b/source/NucData/Energy.cpp
@@ -43,12 +43,6 @@ std::string Energy::to_string() const
   return value_.to_string(false) + " keV";
 }
 
-Energy & Energy::operator=(const Energy &energy)
-{
-  value_ = energy.value_;
-  return *this;
-}
-
 bool operator<(const Energy &left, const Energy &right)
 {
   return left.value_ < right.value_;

--- a/source/NucData/Energy.h
+++ b/source/NucData/Energy.h
@@ -14,8 +14,6 @@ public:
 
   std::string to_string() const;
 
-  Energy & operator=(const Energy &energy);
-
   friend bool operator<(const Energy &left, const Energy &right);
   friend bool operator<(const Energy &left, const double &right);
   friend bool operator>(const Energy &left, const Energy &right);

--- a/source/NucData/Parity.cpp
+++ b/source/NucData/Parity.cpp
@@ -5,11 +5,6 @@ Parity::Parity()
   quality_ = DataQuality::kUnknown;
 }
 
-Parity::Parity(const Parity &other)
-  : QualifiedData(other)
-  , parity_(other.parity_)
-{}
-
 Parity::Parity(const EnumParity& p, const DataQuality& q)
 {
   parity_ = p;

--- a/source/NucData/Parity.h
+++ b/source/NucData/Parity.h
@@ -14,7 +14,6 @@ public:
 
 public:
   Parity();
-  Parity(const Parity &other);
   Parity(const EnumParity& p, const DataQuality& q);
 
   bool valid() const;

--- a/source/NucData/Spin.cpp
+++ b/source/NucData/Spin.cpp
@@ -1,11 +1,6 @@
 #include <NucData/Spin.h>
 #include <util/logger.h>
 
-Spin::Spin(const Spin &spin)
-  : QualifiedData(spin)
-  , numerator_ (spin.numerator_)
-  , denominator_ (spin.denominator_)
-{}
 
 Spin::Spin(uint16_t num, uint16_t denom, DataQuality q)
 {

--- a/source/NucData/Spin.h
+++ b/source/NucData/Spin.h
@@ -8,7 +8,6 @@ class Spin : public QualifiedData
 {
 public:
   Spin() {}
-  Spin(const Spin &spin);
   Spin(uint16_t num, uint16_t denom, DataQuality q);
 
   bool valid();

--- a/source/NucData/Uncert.cpp
+++ b/source/NucData/Uncert.cpp
@@ -44,19 +44,6 @@ Uncert::Uncert(double d, uint16_t sigf, Uncert::Sign s, double symmetricSigma)
 {
 }
 
-Uncert &Uncert::operator =(const Uncert &other)
-{
-  if (this != &other) {
-    value_ = other.value_;
-    lower_sigma_ = other.lower_sigma_;
-    upper_sigma_ = other.upper_sigma_;
-    sign_ = other.sign_;
-    type_ = other.type_;
-    sigfigs_ = other.sigfigs_;
-  }
-  return *this;
-}
-
 double Uncert::value() const
 {
   return value_;

--- a/source/NucData/Uncert.h
+++ b/source/NucData/Uncert.h
@@ -32,7 +32,6 @@ public:
   Uncert(double d, uint16_t sigf, Sign s);
   Uncert(double d, uint16_t sigf, Sign s, double symmetricSigma);
 
-  Uncert & operator=(const Uncert & other);
   Uncert & operator*=(double other);
   Uncert & operator*=(const Uncert &other);
   Uncert & operator+=(const Uncert &other);

--- a/source/Nuclei.cpp
+++ b/source/Nuclei.cpp
@@ -19,7 +19,7 @@ Nuclei::Nuclei(QWidget *parent)
   , preferencesDialog(new QDialog(this))
   , preferencesDialogUi(new Ui::PreferencesDialog)
 {
-  CustomLogger::initLogger(spdlog::level::debug, "nuclei");
+  CustomLogger::initLogger(spdlog::level::debug, "nuclei.log");
 
   ui->setupUi(this);
   setWindowTitle(QCoreApplication::applicationName() + QString(" ") + QCoreApplication::applicationVersion());

--- a/source/Nuclei.cpp
+++ b/source/Nuclei.cpp
@@ -102,7 +102,7 @@ void Nuclei::initialize()
   if (!selectionIndices.isEmpty()) {
     QModelIndex mi = decayProxyModel->index(selectionIndices.at(0).toInt(), 0);
     for (int i=1; i<selectionIndices.size(); i++)
-      mi = mi.child(selectionIndices.at(i).toInt(), 0);
+      mi = decayProxyModel->index(selectionIndices.at(i).toInt(), 0, mi);
     ui->decayTreeView->setCurrentIndex(mi);
     loadSelectedDecay(mi);
   }

--- a/source/Nuclei.cpp
+++ b/source/Nuclei.cpp
@@ -9,6 +9,8 @@
 #include "DecayCascadeItemModel.h"
 #include "DecayCascadeFilterProxyModel.h"
 
+#include <qguiapplication.h>
+#include <qscreen.h>
 #include <util/logger.h>
 
 Nuclei::Nuclei(QWidget *parent)
@@ -60,10 +62,10 @@ void Nuclei::initialize()
   restoreState(s.value("windowState").toByteArray());
 
   QSize wsize = size();
-  if (wsize.width() > QApplication::desktop()->availableGeometry().width())
-    wsize.setWidth(QApplication::desktop()->availableGeometry().width());
-  if (wsize.height() > QApplication::desktop()->availableGeometry().height())
-    wsize.setHeight(QApplication::desktop()->availableGeometry().width());
+  if (wsize.width() > QGuiApplication::screens()[0]->geometry().width())
+    wsize.setWidth(QGuiApplication::screens()[0]->geometry().width());
+  if (wsize.height() > QGuiApplication::screens()[0]->geometry().height())
+    wsize.setHeight(QGuiApplication::screens()[0]->geometry().width());
   this->resize(wsize);
 
   // initialize settings if necessary

--- a/source/SchemeEditor/LevelItem.cpp
+++ b/source/SchemeEditor/LevelItem.cpp
@@ -280,7 +280,7 @@ void LevelItem::align(double leftlinelength, double rightlinelength,
   item->removeFromGroup(spintext_);
   item->removeFromGroup(etext_);
   spintext_->setPos(-leftlinelength + vis.outerLevelTextMargin, -stdBoldFontMetrics.height());
-  etext_->setPos(rightlinelength - vis.outerLevelTextMargin - stdBoldFontMetrics.width(etext_->text()), -etext_->boundingRect().height());
+  etext_->setPos(rightlinelength - vis.outerLevelTextMargin - stdBoldFontMetrics.horizontalAdvance(etext_->text()), -etext_->boundingRect().height());
   item->addToGroup(etext_);
   item->addToGroup(spintext_);
 
@@ -290,7 +290,7 @@ void LevelItem::align(double leftlinelength, double rightlinelength,
   if (parentpos == RightParent && hltext_)
     levelHlPos = -leftlinelength
         - vis.levelToHalfLifeDistance
-        - stdFontMetrics.width(hltext_->text());
+        - stdFontMetrics.horizontalAdvance(hltext_->text());
   else
     levelHlPos = rightlinelength + vis.levelToHalfLifeDistance;
   if (parentpos != NoParent)

--- a/source/SchemeEditor/SchemeEditor.cpp
+++ b/source/SchemeEditor/SchemeEditor.cpp
@@ -10,6 +10,8 @@
 #include <boost/algorithm/string.hpp>
 #include "ScrollZoomView.h"
 
+#include <qpagelayout.h>
+#include <qpagesize.h>
 #include <util/logger.h>
 
 SchemeEditor::SchemeEditor(QWidget *parent)
@@ -99,9 +101,9 @@ void SchemeEditor::on_pushExportPdf_clicked()
 
   QPrinter p(QPrinter::HighResolution);
   p.setOutputFileName(fn);
-  p.setPageMargins(margin, margin, margin, margin, QPrinter::Millimeter);
+  p.setPageMargins(QMarginsF(margin, margin, margin, margin), QPageLayout::Millimeter);
   p.setOutputFormat(QPrinter::PdfFormat);
-  p.setPaperSize(outrect.toRect().size() / scalefactor, QPrinter::Millimeter);
+  p.setPageSize(QPageSize(QSizeF(outrect.width() / scalefactor, outrect.height() / scalefactor), QPageSize::Millimeter));
   p.setDocName("Decay Level Scheme for the decay " + decay_viewer_->name());
   p.setCreator(QString("%1 %2 (%3)").arg(QCoreApplication::applicationName(), QCoreApplication::applicationVersion(), "SchemeEditorURL"));
 

--- a/source/SchemeEditor/SchemeEditorPrefs.cpp
+++ b/source/SchemeEditor/SchemeEditorPrefs.cpp
@@ -43,7 +43,7 @@ SchemeVisualSettings SchemeEditorPrefs::prefs() const
   return prefs_;
 }
 
-void SchemeEditorPrefs::on_fontFamily_activated(const QString &arg1)
+void SchemeEditorPrefs::on_fontFamily_activated()
 {
   prefs_.setStyle(ui->fontFamily->currentFont().family(),
                   ui->fontSize->value());

--- a/source/SchemeEditor/SchemeEditorPrefs.h
+++ b/source/SchemeEditor/SchemeEditorPrefs.h
@@ -21,7 +21,7 @@ class SchemeEditorPrefs : public QDialog
 
   private slots:
 
-    void on_fontFamily_activated(const QString &arg1);
+    void on_fontFamily_activated();
 
     void on_fontSize_editingFinished();
 

--- a/source/SchemeEditor/SchemeGraphics.cpp
+++ b/source/SchemeEditor/SchemeGraphics.cpp
@@ -231,7 +231,7 @@ void SchemeGraphics::alignGraphicsItems()
       double arrowDestY =
           daughter_levels_.at(gamma->to())->ypos()
           - daughter_levels_.at(gamma->from())->ypos();
-      gamma->updateArrow(arrowDestY, max_intensity);
+      gamma->updateArrow(arrowDestY/*, max_intensity*/);
     }
 
     if (daughter_levels_.count(gamma->from()))

--- a/source/SchemeEditor/SchemeGraphics.cpp
+++ b/source/SchemeEditor/SchemeGraphics.cpp
@@ -231,7 +231,7 @@ void SchemeGraphics::alignGraphicsItems()
       double arrowDestY =
           daughter_levels_.at(gamma->to())->ypos()
           - daughter_levels_.at(gamma->from())->ypos();
-      gamma->updateArrow(arrowDestY/*, max_intensity*/);
+      gamma->updateArrow(arrowDestY, max_intensity);
     }
 
     if (daughter_levels_.count(gamma->from()))

--- a/source/SchemeEditor/TransitionItem.cpp
+++ b/source/SchemeEditor/TransitionItem.cpp
@@ -126,7 +126,7 @@ Energy TransitionItem::to() const
   return transition_.to();
 }
 
-void TransitionItem::updateArrow(double arrowDestY, double max_intensity)
+void TransitionItem::updateArrow(double arrowDestY /*, double max_intensity*/)
 {
   item->removeFromGroup(click_area_);
   item->removeFromGroup(arrow_head_);

--- a/source/SchemeEditor/TransitionItem.cpp
+++ b/source/SchemeEditor/TransitionItem.cpp
@@ -126,7 +126,7 @@ Energy TransitionItem::to() const
   return transition_.to();
 }
 
-void TransitionItem::updateArrow(double arrowDestY /*, double max_intensity*/)
+void TransitionItem::updateArrow(double arrowDestY, [[maybe_unused]] double max_intensity)
 {
   item->removeFromGroup(click_area_);
   item->removeFromGroup(arrow_head_);

--- a/source/SchemeEditor/TransitionItem.h
+++ b/source/SchemeEditor/TransitionItem.h
@@ -27,7 +27,7 @@ public:
 
   virtual ~TransitionItem();
 
-  void updateArrow(double arrowDestY /*, double max_intensity*/);
+  void updateArrow(double arrowDestY, [[maybe_unused]] double max_intensity);
   double minimalXDistance() const;
   // Distance between origin and right edge of the bounding rect
   double widthFromOrigin() const;

--- a/source/SchemeEditor/TransitionItem.h
+++ b/source/SchemeEditor/TransitionItem.h
@@ -27,7 +27,7 @@ public:
 
   virtual ~TransitionItem();
 
-  void updateArrow(double arrowDestY, double max_intensity);
+  void updateArrow(double arrowDestY /*, double max_intensity*/);
   double minimalXDistance() const;
   // Distance between origin and right edge of the bounding rect
   double widthFromOrigin() const;

--- a/source/ScrollZoomView.cpp
+++ b/source/ScrollZoomView.cpp
@@ -52,7 +52,7 @@ bool Graphics_view_zoom::eventFilter(QObject *object, QEvent *event)
     QWheelEvent* wheel_event = static_cast<QWheelEvent*>(event);
     if (QApplication::keyboardModifiers() == modifiers_)
     {
-      if (wheel_event->orientation() == Qt::Vertical)
+      if(wheel_event->angleDelta().y() != 0.0)
       {
         double angle = wheel_event->angleDelta().y();
         double factor = qPow(zoom_factor_base_, angle);

--- a/source/ensdf/NuclideData.h
+++ b/source/ensdf/NuclideData.h
@@ -2,6 +2,8 @@
 
 #include <ensdf/LevelsData.h>
 
+#include <QList>
+
 struct NuclideData
 {
   std::list<HistoryRecord> history;

--- a/source/ensdf/Parser.cpp
+++ b/source/ensdf/Parser.cpp
@@ -46,11 +46,6 @@ bool ENSDFParser::good() const
   return !masses_.empty();
 }
 
-std::list<uint16_t> ENSDFParser::masses() const
-{
-  return std::list<uint16_t>(masses_.begin(), masses_.end());
-}
-
 std::string ENSDFParser::directory() const
 {
   return directory_;

--- a/source/ensdf/Parser.h
+++ b/source/ensdf/Parser.h
@@ -62,7 +62,9 @@ public:
 
   bool good() const;
 
-  std::list<uint16_t> masses() const;
+  [[nodiscard]]
+  inline QList<uint16_t> masses() const {return QList<uint16_t> {masses_.begin(), masses_.end()};}
+
   std::string directory() const;
 
   DaughterParser get_dp(uint16_t a);

--- a/source/ensdf/records/Continuation.cpp
+++ b/source/ensdf/records/Continuation.cpp
@@ -222,8 +222,8 @@ parse_continuation(const std::string& crecs)
 }
 
 void merge_continuations(std::map<std::string, Continuation> &to,
-                         const std::map<std::string, Continuation>& from,
-                         const std::string &debug_line)
+                         const std::map<std::string, Continuation>& from)
+                         //const std::string &debug_line)
 {
   for (const auto& cont : from)
   {
@@ -231,18 +231,18 @@ void merge_continuations(std::map<std::string, Continuation> &to,
       continue;
     if (!to.count(cont.first))
       to[cont.first] = cont.second;
-    else
-    {
-      if (to[cont.first].is_uncert()
-          && cont.second.is_uncert())
-      {
+    // else
+    // {
+    //   if (to[cont.first].is_uncert()
+    //       && cont.second.is_uncert())
+    //   {
 
-      }
+    //   }
 //      DBG << debug_line
 //          << " adopted continuation mismatch "
 //          << cont.first
 //          << "  " << to[cont.first]
 //          << "!=" << cont.second;
-    }
+    //}
   }
 }

--- a/source/ensdf/records/Continuation.cpp
+++ b/source/ensdf/records/Continuation.cpp
@@ -222,8 +222,8 @@ parse_continuation(const std::string& crecs)
 }
 
 void merge_continuations(std::map<std::string, Continuation> &to,
-                         const std::map<std::string, Continuation>& from)
-                         //const std::string &debug_line)
+                         const std::map<std::string, Continuation>& from,
+                         [[maybe_unused]] const std::string &debug_line)
 {
   for (const auto& cont : from)
   {
@@ -231,18 +231,9 @@ void merge_continuations(std::map<std::string, Continuation> &to,
       continue;
     if (!to.count(cont.first))
       to[cont.first] = cont.second;
-    // else
-    // {
-    //   if (to[cont.first].is_uncert()
-    //       && cont.second.is_uncert())
-    //   {
-
-    //   }
-//      DBG << debug_line
-//          << " adopted continuation mismatch "
-//          << cont.first
-//          << "  " << to[cont.first]
-//          << "!=" << cont.second;
-    //}
+    else
+    {
+      //TRC("{} adopted continuation mismatch {} {}!={}", debug_line, cont.first, to[cont.first], cont.second);
+    }
   }
 }

--- a/source/ensdf/records/Continuation.cpp
+++ b/source/ensdf/records/Continuation.cpp
@@ -233,7 +233,7 @@ void merge_continuations(std::map<std::string, Continuation> &to,
       to[cont.first] = cont.second;
     else
     {
-      //TRC("{} adopted continuation mismatch {} {}!={}", debug_line, cont.first, to[cont.first], cont.second);
+      TRC("{} adopted continuation mismatch {} {}!={}", debug_line, cont.first, to[cont.first], cont.second);
     }
   }
 }

--- a/source/ensdf/records/Continuation.h
+++ b/source/ensdf/records/Continuation.h
@@ -37,5 +37,5 @@ std::map<std::string, Continuation>
 parse_continuation(const std::string&crecs);
 
 void merge_continuations(std::map<std::string, Continuation>& to,
-                         const std::map<std::string, Continuation>& from);
-//const std::string& debug_line);
+                         const std::map<std::string, Continuation>& from,
+                         [[maybe_unused]] const std::string& debug_line);

--- a/source/ensdf/records/Continuation.h
+++ b/source/ensdf/records/Continuation.h
@@ -2,6 +2,7 @@
 
 #include <NucData/Uncert.h>
 #include <NucData/Spin.h>
+#include <fmt/core.h>
 #include <vector>
 #include <map>
 
@@ -39,3 +40,14 @@ parse_continuation(const std::string&crecs);
 void merge_continuations(std::map<std::string, Continuation>& to,
                          const std::map<std::string, Continuation>& from,
                          [[maybe_unused]] const std::string& debug_line);
+
+// Custom formatter for the Continuation struct
+template <>
+struct fmt::formatter<Continuation> {
+public:
+  constexpr auto parse (format_parse_context& ctx) { return ctx.begin(); }
+  template<typename Context>
+  constexpr auto format(Continuation const& val, Context& ctx) const {
+    return fmt::format_to(ctx.out(), "{}, {}, {}", val.symbols, val.units, val.spin.to_string());
+  }
+};

--- a/source/ensdf/records/Continuation.h
+++ b/source/ensdf/records/Continuation.h
@@ -37,5 +37,5 @@ std::map<std::string, Continuation>
 parse_continuation(const std::string&crecs);
 
 void merge_continuations(std::map<std::string, Continuation>& to,
-                         const std::map<std::string, Continuation>& from,
-                         const std::string& debug_line);
+                         const std::map<std::string, Continuation>& from);
+//const std::string& debug_line);

--- a/source/ensdf/records/Gamma.cpp
+++ b/source/ensdf/records/Gamma.cpp
@@ -66,9 +66,9 @@ void GammaRecord::merge_adopted(const GammaRecord& other)
   }
 
   merge_continuations(continuations_,
-                      other.continuations_,
-                      "<Gamma>(" + nuclide.symbolicName()
-                      + ":" + energy.to_string() + ")");
+                      other.continuations_);
+                      // "<Gamma>(" + nuclide.symbolicName()
+                      // + ":" + energy.to_string() + ")");
 
   for (const auto& com : other.comments)
     comments.push_back(com);

--- a/source/ensdf/records/Gamma.cpp
+++ b/source/ensdf/records/Gamma.cpp
@@ -66,9 +66,8 @@ void GammaRecord::merge_adopted(const GammaRecord& other)
   }
 
   merge_continuations(continuations_,
-                      other.continuations_);
-                      // "<Gamma>(" + nuclide.symbolicName()
-                      // + ":" + energy.to_string() + ")");
+                      other.continuations_,
+                      "<Gamma>(" + nuclide.symbolicName() + ":" + energy.to_string() + ")");
 
   for (const auto& com : other.comments)
     comments.push_back(com);

--- a/source/ensdf/records/LevelRec.cpp
+++ b/source/ensdf/records/LevelRec.cpp
@@ -147,9 +147,9 @@ void LevelRecord::merge_adopted(const LevelRecord& other,
     S = other.S;
 
   merge_continuations(continuations_,
-                      other.continuations_,
-                      "<Level>(" + nuclide.symbolicName()
-                      + ":" + energy.to_string() + ")");
+                      other.continuations_);
+                      // "<Level>(" + nuclide.symbolicName()
+                      // + ":" + energy.to_string() + ")");
 
 //  for (const auto& com : other.comments)
 //    comments.push_back(com);

--- a/source/ensdf/records/LevelRec.cpp
+++ b/source/ensdf/records/LevelRec.cpp
@@ -147,9 +147,9 @@ void LevelRecord::merge_adopted(const LevelRecord& other,
     S = other.S;
 
   merge_continuations(continuations_,
-                      other.continuations_);
-                      // "<Level>(" + nuclide.symbolicName()
-                      // + ":" + energy.to_string() + ")");
+                      other.continuations_,
+                      "<Level>(" + nuclide.symbolicName()
+                      + ":" + energy.to_string() + ")");
 
 //  for (const auto& com : other.comments)
 //    comments.push_back(com);


### PR DESCRIPTION
Changes to get the project compiling without any warnings. Only one left.

I don't know enough Qt to quickly fix this one. Will keep working on it.
```
/home/ijc/repo/nuclei/source/Nuclei.cpp: In member function ‘void Nuclei::initialize()’:
/home/ijc/repo/nuclei/source/Nuclei.cpp:105:20: warning: ‘QModelIndex QModelIndex::child(int, int) const’ is deprecated: Use QAbstractItemModel::index [-Wdeprecated-declarations]
  105 |       mi = mi.child(selectionIndices.at(i).toInt(), 0);
      |            ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/qt5/QtWidgets/qabstractitemview.h:45,
                 from /usr/include/qt5/QtWidgets/qheaderview.h:44,
                 from /usr/include/qt5/QtWidgets/QHeaderView:1,
                 from /home/ijc/repo/nuclei/build/source/nuclei_autogen/include/ui_Nuclei.h:18,
                 from /home/ijc/repo/nuclei/source/Nuclei.cpp:2:
/usr/include/qt5/QtCore/qabstractitemmodel.h:455:20: note: declared here
  455 | inline QModelIndex QModelIndex::child(int arow, int acolumn) const
      |                    ^~~~~~~~~~~

```