### PR TITLE
Prevent having a item = nullptr as part of the transitions

### DIFF
--- a/source/SchemeEditor/SchemeGraphics.cpp
+++ b/source/SchemeEditor/SchemeGraphics.cpp
@@ -133,7 +133,7 @@ void SchemeGraphics::addLevel(Level level)
 
 void SchemeGraphics::addTransition(Transition transition)
 {
-  if (transition.intensity().value() < min_intensity_)
+  if (transition.intensity().value() < min_intensity_ || (!transition.energy().valid()))
     return;
   TransitionItem *transrend
       = new TransitionItem(transition, visual_settings_, scene_);

--- a/source/SchemeEditor/TransitionItem.cpp
+++ b/source/SchemeEditor/TransitionItem.cpp
@@ -34,9 +34,6 @@ TransitionItem::TransitionItem(Transition transition,
                                QGraphicsScene *scene)
   : TransitionItem()
 {
-  if (!transition.energy().valid())
-    return;
-
   transition_ = transition;
 
   pen_ = vis.gammaPen;


### PR DESCRIPTION
Fixes https://github.com/martukas/nuclei/issues/8